### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # combine-language
-This a crate providing an easy way of constructing parsers which can easily parse various programming languages. It has much of the same API as [Text.Parsec.Token](hackage.haskell.org/package/parsec-3.1.9/docs/Text-Parsec-Token.html) but are otherwise a bit different to fit in to the ownership model of rust. The crate is an extension of the [combine](https://github.com/Marwes/combine) crate.
+This a crate providing an easy way of constructing parsers which can easily parse various programming languages. It has much of the same API as [Text.Parsec.Token](http://hackage.haskell.org/package/parsec-3.1.9/docs/Text-Parsec-Token.html) but are otherwise a bit different to fit in to the ownership model of rust. The crate is an extension of the [combine](https://github.com/Marwes/combine) crate.
 
 ## Example
 ```rust


### PR DESCRIPTION
The link to the `Text.Parsec.Token` documentation was missing the `http://`, so it was being treated as a relative link. Not exactly an earth-shattering issue to fix, but figured I'd save you a couple of minutes work :p

On an unrelated note, as someone who's only prior experience of parser combinators was FParsec in F#, combine was way more intuitive to me than any of the other Rust parser libraries. Thanks for the hard work on it :+1: 
