### PR TITLE
Synchronize example from README.md with working one from doctests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This a crate providing an easy way of constructing parsers which can easily pars
 ```rust
 extern crate combine;
 extern crate combine_language;
-use combine::*;
-use combine_language::*;
+use combine::{satisfy, Parser};
+use combine::char::{alpha_num, letter, string};
+use combine_language::{Identifier, LanguageEnv, LanguageDef};
 fn main() {
     let env = LanguageEnv::new(LanguageDef {
         ident: Identifier {


### PR DESCRIPTION
The example in readme does not compile when copy pasted. This pr fixes that by replacing example in readme with one from doctests.