### PR TITLE
Fix float parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,11 +697,8 @@ where
 {
     from_str(recognize::<String, _>((
         optional(token('-')),
-        token('0').or((
-            skip_many1(digit()),
-            optional((token('.'), skip_many(digit()))),
-        )
-            .map(|_| '0')),
+        optional(skip_many1(digit())),
+        optional((token('.'), skip_many(digit()))),
         optional((
             (one_of("eE".chars()), optional(one_of("+-".chars()))),
             skip_many1(digit()),
@@ -948,6 +945,18 @@ mod tests {
 
         let result = env().float().easy_parse("123e1 ");
         assert_eq!(result, Ok((123e1, "")));
+
+        let result = env().float().easy_parse("0.1  ");
+        assert_eq!(result, Ok((0.1, "")));
+
+        let result = env().float().easy_parse(".1  ");
+        assert_eq!(result, Ok((0.1, "")));
+
+        let result = env().float().easy_parse("1.  ");
+        assert_eq!(result, Ok((1.0, "")));
+
+        let result = env().float().easy_parse("1e+0  ");
+        assert_eq!(result, Ok((1.0, "")));
     }
 
     #[test]


### PR DESCRIPTION
`float()` fails to parse `0.1`. I tried to fix it and support other cases like `1.`, `.1` and `1e1`.

```
        let result = env().float().easy_parse("0.1  ");
        assert_eq!(result, Ok((0.1, "")));
```

```
  left: `Ok((0.0, ".1  "))`,
 right: `Ok((0.1, ""))`', src/lib.rs:960:9
```